### PR TITLE
[wip] Use CircleCI Artifacts to create CF Plugin Repo submissions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,3 +52,6 @@ jobs:
             GOOS: "darwin"
             GOARCH: "amd64"
           command: go build -o deploy/cf-recycle-plugin.osx
+
+      - store_artifacts:
+          path: deploy


### PR DESCRIPTION
This PR is a work-in-progress to leverage CircleCI to build binaries for [the CF Plugin submission process](https://github.com/cloudfoundry/cli-plugin-repo#releasing-plugins).

### Acceptance Criteria

- [x] Build binaries in CircleCI
- [x] Save binaries to Artifacts in CircleCI
- [ ] Get Checksum and store it in Artifacts
- [ ] Create an YML file to use for the submission process and store in CircleCI Artifacts